### PR TITLE
Add support for using a ".openscad-format" configuration that is recursively searched up for

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,0 @@
----
-BasedOnStyle: Mozilla
-ColumnLimit: 80
-# SortIncludes: true
-IndentWidth: 4
-AccessModifierOffset: -4
-ContinuationIndentWidth: 4
-TabWidth: 4
-UseTab: Never

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# vscode settings
+.vscode/

--- a/.openscad-format
+++ b/.openscad-format
@@ -1,0 +1,9 @@
+---
+BasedOnStyle: Mozilla
+ColumnLimit: 80
+# SortIncludes: true
+IndentWidth: 4
+AccessModifierOffset: -4
+ContinuationIndentWidth: 4
+TabWidth: 4
+UseTab: Never

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Options:
   -i, --input    Input file to read, file globs allowed (quotes recommended)
                                                                         [string]
   -o, --output   Output file to write                                   [string]
-  -c, --config   Use the specified path to a config using the .clang-format
+  -c, --config   Use the specified path to a config using the .openscad-format
                  style file                                             [string]
   -j, --javadoc  Automatically add {Java,JS}doc-style comment templates to
                  functions and modules where missing                   [boolean]
@@ -47,6 +47,16 @@ Examples:
 This utility requires clang-format, but this is automatically installed for most
 platforms.
 ```
+## Configuration
+This utility by default will search for the configuration file .openscad-format in one of the parent directories. If none is found it will fall back to the default.
+
+The format used is identical to that of clang-format, the easiest way to create the .openscad-format file is using clang-format.
+
+```
+clang-format -style=llvm -dump-config > .openscad-format
+```
+
+See the clang-format docs for the full list of options. At the time of writing this the current styles supported are: LLVM, Google, Chromium, Mozilla, andWebKit.
 
 ## Contribute
 Make sure your PR's pass the unit tests and are free of ESLint errors. To check,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1103,6 +1103,24 @@
         }
       }
     },
+    "find-file-recursively-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-file-recursively-up/-/find-file-recursively-up-1.1.2.tgz",
+      "integrity": "sha512-8IW4C6skOlRlhZry8obUliuZXZ6YT2jS+y4dza9jUVHCU1ejVl6eapbwS8ir3CE6+PzgDuRbSfS6RcrmvUrNzw==",
+      "requires": {
+        "debug": "4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -2056,6 +2074,11 @@
           }
         }
       }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "clang-format": "^1.2.4",
     "diff-match-patch": "^1.0.4",
+    "find-file-recursively-up": "^1.1.2",
     "fs-extra": "^7.0.1",
     "get-stdin": "^6.0.0",
     "globby": "^9.1.0",


### PR DESCRIPTION
This avoids mixing existing .clang-format files present and allows the user to integrate more easily with existing tools.